### PR TITLE
fix trailer parsing

### DIFF
--- a/grpcweb/parser/parser.go
+++ b/grpcweb/parser/parser.go
@@ -79,13 +79,13 @@ func ParseStatusAndTrailer(r io.Reader, length uint32) (*status.Status, metadata
 		}
 
 		t := s.Text()
-		i := strings.Index(t, ": ")
+		i := strings.Index(t, ":")
 		if i == -1 {
 			return nil, nil, io.ErrUnexpectedEOF
 		}
 
 		// Check reserved keys.
-		k, v := strings.ToLower(t[:i]), t[i+2:]
+		k, v := strings.ToLower(t[:i]), strings.TrimSpace(t[i+1:])
 		switch k {
 		case "grpc-status":
 			n, err := strconv.ParseUint(v, 10, 32)
@@ -119,7 +119,7 @@ func ParseStatusAndTrailer(r io.Reader, length uint32) (*status.Status, metadata
 			}
 			headerStat = status.FromProto(s)
 		default:
-			trailer.Append(k, t[i+2:])
+			trailer.Append(k, v)
 		}
 	}
 

--- a/grpcweb/parser/testdata/status_trailer.in
+++ b/grpcweb/parser/testdata/status_trailer.in
@@ -1,3 +1,3 @@
 grpc-status: 0
 trailer_key1: trailer_val1
-trailer_key2: trailer_val2
+trailer_key2:trailer_val2


### PR DESCRIPTION
The spec says:

> Each header field consists of a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace.

and

```
header-field   = field-name ":" OWS field-value OWS
field-name     = token
```

https://datatracker.ietf.org/doc/html/rfc7230#section-3.2