### PR TITLE
Support reading zero-length responses (i.e. empty Response messages).

### DIFF
--- a/grpcweb/parser/parser.go
+++ b/grpcweb/parser/parser.go
@@ -40,9 +40,6 @@ func ParseResponseHeader(r io.Reader) (*Header, error) {
 	}
 
 	length := binary.BigEndian.Uint32(h[1:])
-	if length == 0 {
-		return nil, io.EOF
-	}
 	return &Header{
 		flag:          h[0],
 		ContentLength: length,


### PR DESCRIPTION
In principle, reading a Header with a zero length is still just valid. We process the flag, then read the zero-length body which always succeeds, and then we continue parsing the rest of the response (e.g. the trailer) as normal.