### PR TITLE
Trigger an error in the case of HTTP errors, gRPC errors and unexpected content types.

### DIFF
--- a/grpcweb/transport/transport.go
+++ b/grpcweb/transport/transport.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -60,6 +61,10 @@ func (t *httpTransport) Send(ctx context.Context, endpoint, contentType string, 
 	res, err := t.client.Do(req)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to send the API")
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, nil, fmt.Errorf("%s %s", res.Proto, res.Status)
 	}
 
 	return res.Header, res.Body, nil


### PR DESCRIPTION
Without this, the library misses the fact that the response starts with "HTTP/1.1 404 Not Found", and starts reading the 404 response body as if it were a gRPC message, which then typically fails with a vague error message while the real error is hidden. Or, in other cases, there is no response body which also then fails to process properly, while the real error is in the Headers and also hidden.