### PR TITLE
Add https support by dialing a base URI (including scheme) instead of a hostname.

### DIFF
--- a/grpcweb/grpcweb.go
+++ b/grpcweb/grpcweb.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/ktr0731/grpc-web-go-client/grpcweb/parser"
 	"github.com/ktr0731/grpc-web-go-client/grpcweb/transport"
@@ -16,17 +17,22 @@ import (
 )
 
 type ClientConn struct {
-	host        string
+	baseUri     url.URL
 	dialOptions *dialOptions
 }
 
-func DialContext(host string, opts ...DialOption) (*ClientConn, error) {
+func DialContext(baseUri string, opts ...DialOption) (*ClientConn, error) {
+	parsedUri, err := url.Parse(baseUri)
+	if err != nil {
+		return nil, err
+	}
+
 	opt := defaultDialOptions
 	for _, o := range opts {
 		o(&opt)
 	}
 	return &ClientConn{
-		host:        host,
+		baseUri:     *parsedUri,
 		dialOptions: &opt,
 	}, nil
 }
@@ -35,7 +41,7 @@ func (c *ClientConn) Invoke(ctx context.Context, method string, args, reply inte
 	callOptions := c.applyCallOptions(opts)
 	codec := callOptions.codec
 
-	tr := transport.NewUnary(c.host, nil)
+	tr := transport.NewUnary(c.baseUri, nil)
 	defer tr.Close()
 
 	r, err := encodeRequestBody(codec, args)
@@ -101,7 +107,7 @@ func (c *ClientConn) NewClientStream(desc *grpc.StreamDesc, method string, opts 
 	if !desc.ClientStreams {
 		return nil, errors.New("not a client stream RPC")
 	}
-	tr, err := transport.NewClientStream(c.host, method)
+	tr, err := transport.NewClientStream(c.baseUri, method)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a new transport stream")
 	}
@@ -118,7 +124,7 @@ func (c *ClientConn) NewServerStream(desc *grpc.StreamDesc, method string, opts 
 	}
 	return &serverStream{
 		endpoint:    method,
-		transport:   transport.NewUnary(c.host, nil),
+		transport:   transport.NewUnary(c.baseUri, nil),
 		callOptions: c.applyCallOptions(opts),
 	}, nil
 }

--- a/grpcweb/grpcweb_test.go
+++ b/grpcweb/grpcweb_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -162,7 +163,7 @@ func injectUnaryTransport(t *testing.T, tr transport.UnaryTransport) {
 	t.Cleanup(func() {
 		transport.NewUnary = old
 	})
-	transport.NewUnary = func(string, *transport.ConnectOptions) transport.UnaryTransport {
+	transport.NewUnary = func(url.URL, *transport.ConnectOptions) transport.UnaryTransport {
 		return tr
 	}
 }
@@ -652,7 +653,7 @@ func injectClientStreamTransport(t *testing.T, tr transport.ClientStreamTranspor
 	t.Cleanup(func() {
 		transport.NewClientStream = old
 	})
-	transport.NewClientStream = func(string, string) (transport.ClientStreamTransport, error) {
+	transport.NewClientStream = func(url.URL, string) (transport.ClientStreamTransport, error) {
 		return tr, nil
 	}
 }

--- a/grpcweb/transport/transport.go
+++ b/grpcweb/transport/transport.go
@@ -23,9 +23,9 @@ type UnaryTransport interface {
 }
 
 type httpTransport struct {
-	host   string
-	client *http.Client
-	opts   *ConnectOptions
+	baseUri url.URL
+	client  *http.Client
+	opts    *ConnectOptions
 
 	header http.Header
 
@@ -44,9 +44,8 @@ func (t *httpTransport) Send(ctx context.Context, endpoint, contentType string, 
 		t.sent = true
 	}()
 
-	// TODO: HTTPS support.
-	scheme := "http"
-	u := url.URL{Scheme: scheme, Host: t.host, Path: endpoint}
+	u := t.baseUri
+	u.Path = joinPath(u.Path, endpoint)
 	url := u.String()
 	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {
@@ -70,12 +69,12 @@ func (t *httpTransport) Close() error {
 	return nil
 }
 
-var NewUnary = func(host string, opts *ConnectOptions) UnaryTransport {
+var NewUnary = func(baseUri url.URL, opts *ConnectOptions) UnaryTransport {
 	return &httpTransport{
-		host:   host,
-		client: http.DefaultClient,
-		opts:   opts,
-		header: make(http.Header),
+		baseUri: baseUri,
+		client:  http.DefaultClient,
+		opts:    opts,
+		header:  make(http.Header),
 	}
 }
 
@@ -103,9 +102,7 @@ type ClientStreamTransport interface {
 //
 // spec: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
 type webSocketTransport struct {
-	host     string
-	endpoint string
-
+	uri  url.URL
 	conn *websocket.Conn
 
 	once    sync.Once
@@ -265,20 +262,33 @@ func (t *webSocketTransport) writeMessage(msg int, b []byte) error {
 	return t.conn.WriteMessage(msg, b)
 }
 
-var NewClientStream = func(host, endpoint string) (ClientStreamTransport, error) {
-	// TODO: WebSocket over TLS support.
-	u := url.URL{Scheme: "ws", Host: host, Path: endpoint}
+var NewClientStream = func(uri url.URL, endpoint string) (ClientStreamTransport, error) {
+	if uri.Scheme == "http" {
+		uri.Scheme = "ws"
+	} else if uri.Scheme == "https" {
+		uri.Scheme = "wss"
+	}
+	uri.Path = joinPath(uri.Path, endpoint)
 	h := http.Header{}
 	h.Set("Sec-WebSocket-Protocol", "grpc-websockets")
 	var conn *websocket.Conn
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), h)
+	conn, _, err := websocket.DefaultDialer.Dial(uri.String(), h)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to dial to '%s'", u.String())
+		return nil, errors.Wrapf(err, "failed to dial to '%s'", uri.String())
 	}
 
 	return &webSocketTransport{
-		host:     host,
-		endpoint: endpoint,
-		conn:     conn,
+		uri:  uri,
+		conn: conn,
 	}, nil
+}
+
+func joinPath(a, b string) string {
+	if strings.HasSuffix(a, "/") && strings.HasPrefix(b, "/") {
+		return a + b[1:]
+	} else if !strings.HasSuffix(a, "/") && !strings.HasPrefix(b, "/") {
+		return a + "/" + b
+	} else {
+		return a + b
+	}
 }


### PR DESCRIPTION
Note that this PR introduces a breaking change: the DialContext parameter must be a URL instead of a hostname. We should probably do this in a non-breaking way, e.g.:

- add a separate function `DialContextURL` or something
- if the parameter doesn't parse as a URL, prepend `http://` and see if it parses then, so we have backwards compat

then also perhaps bump the major version of the library to indicate this change.

By the way, I have tested HTTPS support but not WebSocket - I assume the websocket library understands the `wss://` scheme and acts accordingly.